### PR TITLE
Add timeout configuration option

### DIFF
--- a/lib/defra_ruby/area.rb
+++ b/lib/defra_ruby/area.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "area/configuration"
 require_relative "area/no_match_error"
 require_relative "area/response"
 
@@ -9,5 +10,17 @@ require_relative "area/services/water_management_area_service"
 
 module DefraRuby
   module Area
+    class << self
+      # attr_accessor :configuration
+
+      def configure
+        yield(configuration)
+      end
+
+      def configuration
+        @configuration ||= Configuration.new
+        @configuration
+      end
+    end
   end
 end

--- a/lib/defra_ruby/area/configuration.rb
+++ b/lib/defra_ruby/area/configuration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Area
+    class Configuration
+      attr_accessor :timeout
+
+      def initialize
+        @timeout = 3
+      end
+    end
+  end
+end

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -27,7 +27,11 @@ module DefraRuby
       def response_exe
         lambda do
           begin
-            response = RestClient::Request.execute(method: :get, url: url)
+            response = RestClient::Request.execute(
+              method: :get,
+              url: url,
+              timeout: DefraRuby::Area.configuration.timeout
+            )
             area = parse_xml(response)
             raise NoMatchError if area.nil? || area == ""
           rescue StandardError => e

--- a/spec/cassettes/public_face_area_invalid_blank.yml
+++ b/spec/cassettes/public_face_area_invalid_blank.yml
@@ -131,7 +131,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 03 Aug 2019 10:48:37 GMT
+      - Sun, 04 Aug 2019 10:30:09 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -153,5 +153,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Sat, 03 Aug 2019 10:48:37 GMT
+  recorded_at: Sun, 04 Aug 2019 10:30:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_valid.yml
+++ b/spec/cassettes/public_face_area_valid.yml
@@ -128,7 +128,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 03 Aug 2019 10:48:43 GMT
+      - Sun, 04 Aug 2019 10:30:09 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -161,5 +161,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sat, 03 Aug 2019 10:48:44 GMT
+  recorded_at: Sun, 04 Aug 2019 10:30:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/defra_ruby/area/configuration_spec.rb
+++ b/spec/defra_ruby/area/configuration_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module DefraRuby
+  module Area
+    RSpec.describe Configuration do
+      it "sets the appropriate default config settings" do
+        fresh_config = described_class.new
+
+        expect(fresh_config.timeout).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/area/services/public_face_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/public_face_area_service_spec.rb
@@ -58,39 +58,7 @@ module DefraRuby
 
         end
 
-        context "when there is a problem with the Web Feature Service" do
-          before(:each) { VCR.turn_off! }
-          after(:each) { VCR.turn_on! }
-
-          let(:host) { "https://environment.data.gov.uk/" }
-          let(:easting) { 408_602.61 }
-          let(:northing) { 257_535.31 }
-
-          context "and the request times out" do
-            before(:each) { stub_request(:any, /.*#{host}.*/).to_timeout }
-
-            it "returns a failed response" do
-              response = described_class.run(easting, northing)
-              expect(response).to be_a(Response)
-              expect(response).to_not be_successful
-              expect(response.area).to be_nil
-              expect(response.error).to_not be_nil
-            end
-          end
-
-          context "and request returns an error" do
-            before(:each) { stub_request(:any, /.*#{host}.*/).to_raise(SocketError) }
-
-            it "returns a failed response" do
-              response = described_class.run(easting, northing)
-              expect(response).to be_a(Response)
-              expect(response).to_not be_successful
-              expect(response.area).to be_nil
-              expect(response.error).to_not be_nil
-            end
-          end
-
-        end
+        include_examples "handle request errors"
       end
     end
   end

--- a/spec/defra_ruby/area/services/public_face_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/public_face_area_service_spec.rb
@@ -57,6 +57,40 @@ module DefraRuby
           end
 
         end
+
+        context "when there is a problem with the Web Feature Service" do
+          before(:each) { VCR.turn_off! }
+          after(:each) { VCR.turn_on! }
+
+          let(:host) { "https://environment.data.gov.uk/" }
+          let(:easting) { 408_602.61 }
+          let(:northing) { 257_535.31 }
+
+          context "and the request times out" do
+            before(:each) { stub_request(:any, /.*#{host}.*/).to_timeout }
+
+            it "returns a failed response" do
+              response = described_class.run(easting, northing)
+              expect(response).to be_a(Response)
+              expect(response).to_not be_successful
+              expect(response.area).to be_nil
+              expect(response.error).to_not be_nil
+            end
+          end
+
+          context "and request returns an error" do
+            before(:each) { stub_request(:any, /.*#{host}.*/).to_raise(SocketError) }
+
+            it "returns a failed response" do
+              response = described_class.run(easting, northing)
+              expect(response).to be_a(Response)
+              expect(response).to_not be_successful
+              expect(response.area).to be_nil
+              expect(response.error).to_not be_nil
+            end
+          end
+
+        end
       end
     end
   end

--- a/spec/defra_ruby/area/services/water_management_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/water_management_area_service_spec.rb
@@ -57,6 +57,8 @@ module DefraRuby
           end
 
         end
+
+        include_examples "handle request errors"
       end
     end
   end

--- a/spec/defra_ruby/area_spec.rb
+++ b/spec/defra_ruby/area_spec.rb
@@ -9,4 +9,22 @@ RSpec.describe DefraRuby::Area do
       expect(DefraRuby::Area::VERSION).to match(/\d+\.\d+\.\d+/)
     end
   end
+
+  describe "#configuration" do
+    context "when the host app has not provided configuration" do
+      it "returns a DefraRuby::Area::Configuration instance" do
+        expect(described_class.configuration).to be_an_instance_of(DefraRuby::Area::Configuration)
+      end
+    end
+
+    context "when the host app has provided configuration" do
+      let(:timeout) { 10 }
+
+      it "returns an DefraRuby::Area::Configuration instance with a matching timeout" do
+        described_class.configure { |config| config.timeout = timeout }
+
+        expect(described_class.configuration.timeout).to eq(timeout)
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/handle_request_errors.rb
+++ b/spec/support/shared_examples/handle_request_errors.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "handle request errors" do
+  context "when there is a problem with the Web Feature Service" do
+    before(:each) { VCR.turn_off! }
+    after(:each) { VCR.turn_on! }
+
+    let(:host) { "https://environment.data.gov.uk/" }
+    let(:easting) { 408_602.61 }
+    let(:northing) { 257_535.31 }
+
+    context "and the request times out" do
+      before(:each) { stub_request(:any, /.*#{host}.*/).to_timeout }
+
+      it "returns a failed response" do
+        response = described_class.run(easting, northing)
+        expect(response).to be_a(DefraRuby::Area::Response)
+        expect(response).to_not be_successful
+        expect(response.area).to be_nil
+        expect(response.error).to_not be_nil
+      end
+    end
+
+    context "and the request returns an error" do
+      before(:each) { stub_request(:any, /.*#{host}.*/).to_raise(SocketError) }
+
+      it "returns a failed response" do
+        response = described_class.run(easting, northing)
+        expect(response).to be_a(DefraRuby::Area::Response)
+        expect(response).to_not be_successful
+        expect(response.area).to be_nil
+        expect(response.error).to_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
By default the timeout for a [rest-client](https://github.com/rest-client/rest-client#timeouts) request is 60 seconds.

Due to the known 'flaky' nature of the WFS's were calling we don't want users in the service left hanging for 60 seconds whilst the calling app waits to find out what area a registration belongs to.

So this change adds the timeout option to our rest-client calls, along with a configuration option that host apps can use to override this value.