### PR TITLE
Resolve hakiri security warning for nokogiri

### DIFF
--- a/defra_ruby_area.gemspec
+++ b/defra_ruby_area.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   # The response from the area WFS services is in XML so we need Nokogiri to
   # parse it
-  spec.add_dependency "nokogiri", "~> 1.10"
+  spec.add_dependency "nokogiri", "~> 1.10.3"
 
   # Use rest-client for external requests, eg. to Companies House
   spec.add_dependency "rest-client", "~> 2.0"


### PR DESCRIPTION
Every PR we are submitting for defra-ruby-area at the moment is getting flagged with a security warning because of Nokogiri.

Specifically its [CVE-2019-11068](https://hakiri.io/github/DEFRA/defra-ruby-area/master/414dcc80725d7b10358b8f4ac21206e94081aab6). This has been fixed in Nokogiri 10.3, and if you were to pull down this repo now and run bundle install, that's what you'd get.

However we think Hakiri keeps flagging us because our gemspec states only that version 1.10 is acceptable. Hence this change to move the minimum version of Nokogiri to 1.10.3.