### PR TITLE
Remove unnecessary rescue in base_service

### DIFF
--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -26,17 +26,14 @@ module DefraRuby
 
       def response_exe
         lambda do
-          begin
-            response = RestClient::Request.execute(
-              method: :get,
-              url: url,
-              timeout: DefraRuby::Area.configuration.timeout
-            )
-            area = parse_xml(response)
-            raise NoMatchError if area.nil? || area == ""
-          rescue StandardError => e
-            raise e
-          end
+          response = RestClient::Request.execute(
+            method: :get,
+            url: url,
+            timeout: DefraRuby::Area.configuration.timeout
+          )
+          area = parse_xml(response)
+          raise NoMatchError if area.nil? || area == ""
+
           { area: area }
         end
       end


### PR DESCRIPTION
Prior to this change we were rescuing the error when calling the WFS, but then raising it again.

We think it was because of a misplaced belief that without it the `DefraRuby::Area::Response` object would then not get the error to save within the response object. A review of the code and a quick test though confirmed this is rubbish.

Hence this change to remove it.