### PR TITLE
Breakdown url() in services for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ As you can see it uses XML within query, and will return the result in XML.
 
 Checkout these additional resources we have found helpful in understanding how WFS's work.
 
+- [Web Feature Service](http://www.opengeospatial.org/standards/wfs)
 - [Communicating with a WFS service in a web browser](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/communicating-with-a-wfs-service-in-a-web-browser.htm)
 - [Introduction to Web Feature Service](https://geoserver.geo-solutions.it/edu/en/vector_data/wfsintro.html)
 - [WFS reference](https://docs.geoserver.org/latest/en/user/services/wfs/reference.html)

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -39,9 +39,7 @@ module DefraRuby
       end
 
       def url
-        # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=#{filter}"
-        # rubocop:enable Metrics/LineLength
+        "#{domain}/spatialdata/#{dataset}/wfs?#{url_params}"
       end
 
       def parse_xml(response)
@@ -59,6 +57,18 @@ module DefraRuby
 
       def dataset
         implemented_in_subclass
+      end
+
+      def url_params
+        {
+          "SERVICE" => service,
+          "VERSION" => version,
+          "REQUEST" => request,
+          "typeName" => type_name,
+          "propertyName" => property_name,
+          "SRSName" => srs_name,
+          "Filter" => filter
+        }.map { |k, v| "#{k}=#{v}" }.join("&")
       end
 
       # There are generally 3 kinds of GIS services; WFS, WMS, and WCS.

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -59,6 +59,16 @@ module DefraRuby
         implemented_in_subclass
       end
 
+      # Used to tell the WFS what function you wish it to perform. In the case
+      # of `GetFeature` this means
+      #
+      #   Returns a selection of features from a data source including geometry and attribute values
+      #
+      # https://docs.geoserver.org/latest/en/user/services/wfs/reference.html#getfeature
+      def operation
+        "REQUEST=GetFeature"
+      end
+
       def type_name
         implemented_in_subclass
       end

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -74,6 +74,15 @@ module DefraRuby
         "SERVICE=WFS"
       end
 
+      # Currently there are 3 versions of the WFS standard; 1.0, 1.1 and 2.0.
+      #
+      # The WFS's we are working with only support version 1.0. A WFS may
+      # suppport multiple versions hence you need to state the version in the
+      # request.
+      def version
+        "VERSION=1.0.0"
+      end
+
       # Used to tell the WFS what kind of request you are making. In the case
       # of `GetFeature` this means
       #

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -47,16 +47,8 @@ module DefraRuby
         "//wfs:FeatureCollection/gml:featureMember/ms:#{type_name}/ms:long_name"
       end
 
-      def url
-        implemented_in_subclass
-      end
-
       def domain
         "https://environment.data.gov.uk"
-      end
-
-      def dataset
-        implemented_in_subclass
       end
 
       # There are generally 3 kinds of GIS services; WFS, WMS, and WCS.
@@ -122,6 +114,16 @@ module DefraRuby
       # it to reduce the size of the response.
       def property_name
         "long_name"
+      end
+
+      def url
+        # rubocop:disable Metrics/LineLength
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        # rubocop:enable Metrics/LineLength
+      end
+
+      def dataset
+        implemented_in_subclass
       end
 
       def type_name

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -50,7 +50,7 @@ module DefraRuby
       end
 
       def response_xml_path
-        "//wfs:FeatureCollection/gml:featureMember/ms:#{type_name}/ms:long_name"
+        "//wfs:FeatureCollection/gml:featureMember/#{type_name}/ms:long_name"
       end
 
       def domain

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -74,7 +74,8 @@ module DefraRuby
         "WFS"
       end
 
-      # Currently there are 3 versions of the WFS standard; 1.0, 1.1 and 2.0.
+      # Currently there are various versions of the WFS standard, for example
+      # 1.0, 1.1 and 2.0.
       #
       # The WFS's we are working with only support version 1.0. A WFS may
       # suppport multiple versions hence you need to state the version in the

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -118,8 +118,32 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=#{filter}"
         # rubocop:enable Metrics/LineLength
+      end
+
+      # WFS's use filters in GetFeature requests to return data that only
+      # matches a certain criteria.
+      #
+      # https://docs.geoserver.org/latest/en/user/filter/function.html
+      #
+      # There are various formats you can use for doing those, though it will be
+      # dependent on what the WFS supports. In our case we use XML-based Filter
+      # Encoding language because
+      #
+      # * this was how the team that manage the WFS have always provided their
+      #   examples
+      # * we know this format is supported by the WFS's we are interacting with
+      #
+      # The others are CQL and ECQL. https://docs.geoserver.org/latest/en/user/tutorials/cql/cql_tutorial.html
+      #
+      # Our filter is looking for the result where our coordinates intersect
+      # with the feature property +SHAPE+, with +SHAPE+ being a
+      # +MultiPolygonPropertyType+.
+      #
+      # http://xml.fmi.fi/namespace/meteorology/conceptual-model/meteorological-objects/2009/04/28/docindex647.html
+      def filter
+        "(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
       end
 
       def dataset

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -71,7 +71,7 @@ module DefraRuby
       # phenomenon. This object has a set of properties associated with each
       # having a name, a type, and a value.
       def service
-        "SERVICE=WFS"
+        "WFS"
       end
 
       # Currently there are 3 versions of the WFS standard; 1.0, 1.1 and 2.0.
@@ -80,7 +80,7 @@ module DefraRuby
       # suppport multiple versions hence you need to state the version in the
       # request.
       def version
-        "VERSION=1.0.0"
+        "1.0.0"
       end
 
       # Used to tell the WFS what kind of request you are making. In the case
@@ -90,7 +90,7 @@ module DefraRuby
       #
       # https://docs.geoserver.org/latest/en/user/services/wfs/reference.html#getfeature
       def request
-        "REQUEST=GetFeature"
+        "GetFeature"
       end
 
       def type_name

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -47,14 +47,20 @@ module DefraRuby
         xml.xpath(response_xml_path).text
       end
 
+      # XML path to the value we wish to extract in the WFS query response.
       def response_xml_path
         "//wfs:FeatureCollection/gml:featureMember/#{type_name}/ms:long_name"
       end
 
+      # Domain where the WFS is hosted
       def domain
         "https://environment.data.gov.uk"
       end
 
+      # Name of the Environment Agency dataset we are querying.
+      #
+      # Not actually a part of the WFS interface or spec. This is simply how
+      # we route through to the right 'dataset' (how the EA terms it).
       def dataset
         implemented_in_subclass
       end
@@ -106,6 +112,10 @@ module DefraRuby
         "GetFeature"
       end
 
+      # Name of the feature we wish to query.
+      #
+      # A WFS may host multiple features, so you need to specify which one you
+      # are querying in the url.
       def type_name
         implemented_in_subclass
       end

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -94,6 +94,24 @@ module DefraRuby
         "GetFeature"
       end
 
+      # SRS stands for Spatial Reference System. It can also be known as a
+      # Coordinate Reference System (CRS). It is a coordinate-based local,
+      # regional or global system used to locate geographical entities.
+      # A spatial reference system defines a specific map projection, as well as
+      # transformations between different spatial reference systems.
+      #
+      # The SRSName paramater tells the WFS which SRS definition to use. The
+      # value is an EPSG (European Petroleum Survey Group) code. You can find a
+      # list of them at https://spatialreference.org/ref/epsg/
+      #
+      # EPSG:27700 refers to OSGB 1936 - British National Grid
+      # (https://spatialreference.org/ref/epsg/27700/)
+      #
+      # For more info on SRS read https://en.wikipedia.org/wiki/Spatial_reference_system
+      def srs_name
+        "EPSG:27700"
+      end
+
       def type_name
         implemented_in_subclass
       end

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -44,7 +44,7 @@ module DefraRuby
       end
 
       def response_xml_path
-        implemented_in_subclass
+        "//wfs:FeatureCollection/gml:featureMember/ms:#{type_name}/ms:long_name"
       end
 
       def url
@@ -53,6 +53,10 @@ module DefraRuby
 
       def domain
         "https://environment.data.gov.uk"
+      end
+
+      def type_name
+        implemented_in_subclass
       end
 
       def implemented_in_subclass

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -38,6 +38,12 @@ module DefraRuby
         end
       end
 
+      def url
+        # rubocop:disable Metrics/LineLength
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=#{filter}"
+        # rubocop:enable Metrics/LineLength
+      end
+
       def parse_xml(response)
         xml = Nokogiri::XML(response)
         xml.xpath(response_xml_path).text
@@ -49,6 +55,10 @@ module DefraRuby
 
       def domain
         "https://environment.data.gov.uk"
+      end
+
+      def dataset
+        implemented_in_subclass
       end
 
       # There are generally 3 kinds of GIS services; WFS, WMS, and WCS.
@@ -86,6 +96,22 @@ module DefraRuby
         "GetFeature"
       end
 
+      def type_name
+        implemented_in_subclass
+      end
+
+      # Specify which attribute of the feature we want to return. You can check
+      # the attributes of a feature by making +DescribeFeatureType+ request.
+      #
+      # https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=DescribeFeatureType
+      #
+      # In our case the administrative boundary features contain a number of
+      # properties, but we are only interested in +long_name+ hence we specify
+      # it to reduce the size of the response.
+      def property_name
+        "long_name"
+      end
+
       # SRS stands for Spatial Reference System. It can also be known as a
       # Coordinate Reference System (CRS). It is a coordinate-based local,
       # regional or global system used to locate geographical entities.
@@ -102,24 +128,6 @@ module DefraRuby
       # For more info on SRS read https://en.wikipedia.org/wiki/Spatial_reference_system
       def srs_name
         "EPSG:27700"
-      end
-
-      # Specify which attribute of the feature we want to return. You can check
-      # the attributes of a feature by making +DescribeFeatureType+ request.
-      #
-      # https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=DescribeFeatureType
-      #
-      # In our case the administrative boundary features contain a number of
-      # properties, but we are only interested in +long_name+ hence we specify
-      # it to reduce the size of the response.
-      def property_name
-        "long_name"
-      end
-
-      def url
-        # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=#{filter}"
-        # rubocop:enable Metrics/LineLength
       end
 
       # WFS's use filters in GetFeature requests to return data that only
@@ -146,14 +154,6 @@ module DefraRuby
         # rubocop:disable Metrics/LineLength
         "(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
-      end
-
-      def dataset
-        implemented_in_subclass
-      end
-
-      def type_name
-        implemented_in_subclass
       end
 
       def implemented_in_subclass

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -43,12 +43,16 @@ module DefraRuby
         xml.xpath(response_xml_path).text
       end
 
+      def response_xml_path
+        implemented_in_subclass
+      end
+
       def url
         implemented_in_subclass
       end
 
-      def response_xml_path
-        implemented_in_subclass
+      def domain
+        "https://environment.data.gov.uk"
       end
 
       def implemented_in_subclass

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -55,6 +55,10 @@ module DefraRuby
         "https://environment.data.gov.uk"
       end
 
+      def dataset
+        implemented_in_subclass
+      end
+
       def type_name
         implemented_in_subclass
       end

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -143,7 +143,9 @@ module DefraRuby
       #
       # http://xml.fmi.fi/namespace/meteorology/conceptual-model/meteorological-objects/2009/04/28/docindex647.html
       def filter
+        # rubocop:disable Metrics/LineLength
         "(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        # rubocop:enable Metrics/LineLength
       end
 
       def dataset

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -74,13 +74,13 @@ module DefraRuby
         "SERVICE=WFS"
       end
 
-      # Used to tell the WFS what function you wish it to perform. In the case
+      # Used to tell the WFS what kind of request you are making. In the case
       # of `GetFeature` this means
       #
-      #   Returns a selection of features from a data source including geometry and attribute values
+      #   Return a selection of features from a data source including geometry and attribute values
       #
       # https://docs.geoserver.org/latest/en/user/services/wfs/reference.html#getfeature
-      def operation
+      def request
         "REQUEST=GetFeature"
       end
 

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -151,9 +151,22 @@ module DefraRuby
       #
       # http://xml.fmi.fi/namespace/meteorology/conceptual-model/meteorological-objects/2009/04/28/docindex647.html
       def filter
-        # rubocop:disable Metrics/LineLength
-        "(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
-        # rubocop:enable Metrics/LineLength
+        # The filter is done in this way purely for readability. It could just
+        # as easily been a one line string statement, but we think this is
+        # better.
+        filter = <<-XML
+          (
+            <Filter>
+              <Intersects>
+                <PropertyName>SHAPE</PropertyName>
+                <gml:Point>
+                  <gml:coordinates>#{easting},#{northing}</gml:coordinates>
+                </gml:Point>
+              </Intersects>
+            </Filter>
+          )
+        XML
+        filter.strip.squeeze(" ").gsub(/\s+/, "")
       end
 
       def implemented_in_subclass

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -59,6 +59,21 @@ module DefraRuby
         implemented_in_subclass
       end
 
+      # There are generally 3 kinds of GIS services; WFS, WMS, and WCS.
+      #
+      # * WFS - allows features to be queried, updated, created, or deleted by the client
+      # * WMS - returns map images based on the request made
+      # * WCS - transfer "coverages", ie. objects covering a geographical area
+      #
+      # We are querying a 'feature' hence we request to use the WFS service.
+      #
+      # N.B. A feature is an Object that is an abstraction of a real world
+      # phenomenon. This object has a set of properties associated with each
+      # having a name, a type, and a value.
+      def service
+        "SERVICE=WFS"
+      end
+
       # Used to tell the WFS what function you wish it to perform. In the case
       # of `GetFeature` this means
       #

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -112,6 +112,18 @@ module DefraRuby
         "EPSG:27700"
       end
 
+      # Specify which attribute of the feature we want to return. You can check
+      # the attributes of a feature by making +DescribeFeatureType+ request.
+      #
+      # https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=DescribeFeatureType
+      #
+      # In our case the administrative boundary features contain a number of
+      # properties, but we are only interested in +long_name+ hence we specify
+      # it to reduce the size of the response.
+      def property_name
+        "long_name"
+      end
+
       def type_name
         implemented_in_subclass
       end

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&VERSION=1.0.0&#{request}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&#{version}&#{request}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -9,13 +9,17 @@ module DefraRuby
 
       private
 
+      def dataset
+        "administrative-boundaries-environment-agency-and-natural-england-public-face-areas"
+      end
+
       def type_name
         "Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas"
       end
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=WFS&VERSION=1.0.0&#{operation}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&VERSION=1.0.0&#{operation}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&#{version}&#{request}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&#{version}&#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&VERSION=1.0.0&#{operation}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&VERSION=1.0.0&#{request}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=WFS&VERSION=1.0.0&#{operation}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -17,12 +17,6 @@ module DefraRuby
         "Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas"
       end
 
-      def url
-        # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
-        # rubocop:enable Metrics/LineLength
-      end
-
     end
   end
 end

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -14,7 +14,7 @@ module DefraRuby
       end
 
       def type_name
-        "Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas"
+        "ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas"
       end
 
     end

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -16,8 +16,12 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
+      end
+
+      def domain
+        "https://environment.data.gov.uk"
       end
 
     end

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -9,19 +9,14 @@ module DefraRuby
 
       private
 
-      def response_xml_path
-        type_name = "Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas"
-        "//wfs:FeatureCollection/gml:featureMember/ms:#{type_name}/ms:long_name"
+      def type_name
+        "Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas"
       end
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
-      end
-
-      def domain
-        "https://environment.data.gov.uk"
       end
 
     end

--- a/lib/defra_ruby/area/services/public_face_area_service.rb
+++ b/lib/defra_ruby/area/services/public_face_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&#{version}&#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&VERSION=1.0.0&#{request}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&#{version}&#{request}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -14,7 +14,7 @@ module DefraRuby
       end
 
       def type_name
-        "Administrative_Boundaries_Water_Management_Areas"
+        "ms:Administrative_Boundaries_Water_Management_Areas"
       end
 
     end

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=WFS&VERSION=1.0.0&#{operation}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&VERSION=1.0.0&#{operation}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&#{version}&#{request}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&#{version}&#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -9,13 +9,17 @@ module DefraRuby
 
       private
 
+      def dataset
+        "administrative-boundaries-water-management-areas"
+      end
+
       def type_name
         "Administrative_Boundaries_Water_Management_Areas"
       end
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&VERSION=1.0.0&#{operation}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&VERSION=1.0.0&#{request}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=WFS&VERSION=1.0.0&#{operation}&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -17,12 +17,6 @@ module DefraRuby
         "Administrative_Boundaries_Water_Management_Areas"
       end
 
-      def url
-        # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=#{property_name}&SRSName=#{srs_name}&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
-        # rubocop:enable Metrics/LineLength
-      end
-
     end
   end
 end

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -16,7 +16,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:Administrative_Boundaries_Water_Management_Areas&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:Administrative_Boundaries_Water_Management_Areas&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -19,7 +19,7 @@ module DefraRuby
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/#{dataset}/wfs?#{service}&#{version}&#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/#{dataset}/wfs?SERVICE=#{service}&VERSION=#{version}&REQUEST=#{request}&typeName=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/defra_ruby/area/services/water_management_area_service.rb
+++ b/lib/defra_ruby/area/services/water_management_area_service.rb
@@ -9,14 +9,13 @@ module DefraRuby
 
       private
 
-      def response_xml_path
-        type_name = "Administrative_Boundaries_Water_Management_Areas"
-        "//wfs:FeatureCollection/gml:featureMember/ms:#{type_name}/ms:long_name"
+      def type_name
+        "Administrative_Boundaries_Water_Management_Areas"
       end
 
       def url
         # rubocop:disable Metrics/LineLength
-        "#{domain}/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:Administrative_Boundaries_Water_Management_Areas&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
+        "#{domain}/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&typeNames=ms:#{type_name}&propertyName=long_name&SRSName=EPSG:27700&Filter=(<Filter><Intersects><PropertyName>SHAPE</PropertyName><gml:Point><gml:coordinates>#{easting},#{northing}</gml:coordinates></gml:Point></Intersects></Filter>)"
         # rubocop:enable Metrics/LineLength
       end
 

--- a/spec/cassettes/public_face_area_invalid_blank.yml
+++ b/spec/cassettes/public_face_area_invalid_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=2.0.0&propertyName=long_name,short_name&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,115 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 09 Jul 2019 15:45:40 GMT
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '635'
-      Connection:
-      - keep-alive
-      Cache-Control:
-      - private
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Powered-By:
-      - ASP.NET
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="utf-8" ?>
-        <ExceptionReport
-         version="2.0.0" xmlns="http://www.opengis.net/ows/1.1"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsAll.xsd"
-        >
-          <Exception exceptionCode="InvalidParameterValue" locator="Unknown">
-            <ExceptionText><![CDATA[The geometry was not recognized.]]></ExceptionText>
-          </Exception>
-          <Exception exceptionCode="OperationProcessingFailed" locator="Unknown">
-            <ExceptionText><![CDATA[Operator 'Intersects' can't parse geometry.]]></ExceptionText>
-          </Exception>
-        </ExceptionReport>
-    http_version: 
-  recorded_at: Tue, 09 Jul 2019 15:45:40 GMT
-- request:
-    method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=2.0.0&propertyName=long_name&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
-      Host:
-      - environment.data.gov.uk
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Thu, 01 Aug 2019 10:07:13 GMT
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '635'
-      Connection:
-      - keep-alive
-      Cache-Control:
-      - private
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Powered-By:
-      - ASP.NET
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="utf-8" ?>
-        <ExceptionReport
-         version="2.0.0" xmlns="http://www.opengis.net/ows/1.1"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsAll.xsd"
-        >
-          <Exception exceptionCode="InvalidParameterValue" locator="Unknown">
-            <ExceptionText><![CDATA[The geometry was not recognized.]]></ExceptionText>
-          </Exception>
-          <Exception exceptionCode="OperationProcessingFailed" locator="Unknown">
-            <ExceptionText><![CDATA[Operator 'Intersects' can't parse geometry.]]></ExceptionText>
-          </Exception>
-        </ExceptionReport>
-    http_version: 
-  recorded_at: Thu, 01 Aug 2019 10:07:13 GMT
-- request:
-    method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
-      Host:
-      - environment.data.gov.uk
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Sun, 04 Aug 2019 10:30:09 GMT
+      - Mon, 05 Aug 2019 16:31:59 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -153,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Sun, 04 Aug 2019 10:30:09 GMT
+  recorded_at: Mon, 05 Aug 2019 16:31:59 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_invalid_coords.yml
+++ b/spec/cassettes/public_face_area_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=2.0.0&propertyName=long_name,short_name&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
       Host:
       - environment.data.gov.uk
   response:
@@ -23,11 +23,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 31 Jul 2019 19:06:40 GMT
+      - Mon, 05 Aug 2019 16:31:58 GMT
       Content-Type:
       - application/xml
       Content-Length:
-      - '1024'
+      - '1070'
       Connection:
       - keep-alive
       Cache-Control:
@@ -40,8 +40,13 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="utf-8" ?>
-        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" timeStamp="2019-07-31T19:06:40Z" numberMatched="unknown" numberReturned="0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=2.0.0%26request=DescribeFeatureType">
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Wed, 31 Jul 2019 19:06:40 GMT
+  recorded_at: Mon, 05 Aug 2019 16:31:59 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_valid.yml
+++ b/spec/cassettes/public_face_area_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=2.0.0&propertyName=long_name,short_name&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,112 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 09 Jul 2019 10:13:56 GMT
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '1607'
-      Connection:
-      - keep-alive
-      Cache-Control:
-      - private
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Powered-By:
-      - ASP.NET
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0" encoding="utf-8" ?>
-        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" timeStamp="2019-07-09T10:13:56Z" numberMatched="unknown" numberReturned="1" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=2.0.0%26request=DescribeFeatureType">
-          <wfs:member>
-            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas gml:id="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.23">
-              <ms:OBJECTID>23</ms:OBJECTID>
-              <ms:long_name>West Midlands</ms:long_name>
-              <ms:short_name>West Midlands</ms:short_name>
-              <ms:st_area_shape_>14543741870.84492</ms:st_area_shape_>
-              <ms:st_perimeter_shape_>1043376.795941756</ms:st_perimeter_shape_>
-            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
-          </wfs:member>
-        </wfs:FeatureCollection>
-    http_version: 
-  recorded_at: Tue, 09 Jul 2019 10:13:56 GMT
-- request:
-    method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=2.0.0&propertyName=long_name&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
-      Host:
-      - environment.data.gov.uk
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Thu, 01 Aug 2019 10:07:06 GMT
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '1556'
-      Connection:
-      - keep-alive
-      Cache-Control:
-      - private
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Powered-By:
-      - ASP.NET
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0" encoding="utf-8" ?>
-        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" timeStamp="2019-08-01T10:07:06Z" numberMatched="unknown" numberReturned="1" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=2.0.0%26request=DescribeFeatureType">
-          <wfs:member>
-            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas gml:id="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.23">
-              <ms:OBJECTID>23</ms:OBJECTID>
-              <ms:long_name>West Midlands</ms:long_name>
-              <ms:st_area_shape_>14543741870.84492</ms:st_area_shape_>
-              <ms:st_perimeter_shape_>1043376.795941756</ms:st_perimeter_shape_>
-            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
-          </wfs:member>
-        </wfs:FeatureCollection>
-    http_version: 
-  recorded_at: Thu, 01 Aug 2019 10:07:05 GMT
-- request:
-    method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeNames=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
-      Host:
-      - environment.data.gov.uk
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Sun, 04 Aug 2019 10:30:09 GMT
+      - Mon, 05 Aug 2019 16:31:58 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -161,5 +56,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 04 Aug 2019 10:30:09 GMT
+  recorded_at: Mon, 05 Aug 2019 16:31:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_blank.yml
+++ b/spec/cassettes/water_management_area_invalid_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeNames=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 01 Aug 2019 08:44:09 GMT
+      - Mon, 05 Aug 2019 16:31:54 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Thu, 01 Aug 2019 08:44:09 GMT
+  recorded_at: Mon, 05 Aug 2019 16:31:54 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_coords.yml
+++ b/spec/cassettes/water_management_area_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeNames=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 01 Aug 2019 08:44:09 GMT
+      - Mon, 05 Aug 2019 16:31:57 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Thu, 01 Aug 2019 08:44:09 GMT
+  recorded_at: Mon, 05 Aug 2019 16:31:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_valid.yml
+++ b/spec/cassettes/water_management_area_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeNames=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 01 Aug 2019 08:44:09 GMT
+      - Mon, 05 Aug 2019 16:31:57 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -56,5 +56,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Thu, 01 Aug 2019 08:44:08 GMT
+  recorded_at: Mon, 05 Aug 2019 16:31:58 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
After a review of the gem by the team, it was felt that breaking down the url we use to call a service (accessed from `DefraRuby::Area::MyService.url`) into its constituent parts would

- remove the need for the rubocop exception
- make it easier to see the constituent parts of the url
- name some so new users get a better understanding of what they are for

So this change retains the `url()` method, but it breaks down the formation of the url into smaller methods that return each part.