### PR TITLE
Extract code and short name from WFS's

### DIFF
--- a/lib/defra_ruby/area.rb
+++ b/lib/defra_ruby/area.rb
@@ -3,6 +3,7 @@
 require_relative "area/configuration"
 require_relative "area/no_match_error"
 require_relative "area/response"
+require_relative "area/area"
 
 require_relative "area/services/base_area_service"
 require_relative "area/services/public_face_area_service"

--- a/lib/defra_ruby/area/area.rb
+++ b/lib/defra_ruby/area/area.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Area
+    class Area
+      attr_reader :code, :long_name, :short_name
+
+      def initialize(code, long_name, short_name)
+        @code = code
+        @long_name = long_name
+        @short_name = short_name
+      end
+
+      def matched?
+        "#{@code}#{@long_name}#{@short_name}" != ""
+      end
+
+    end
+  end
+end

--- a/spec/cassettes/public_face_area_invalid_blank.yml
+++ b/spec/cassettes/public_face_area_invalid_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2019 16:31:59 GMT
+      - Fri, 09 Aug 2019 17:08:26 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 16:31:59 GMT
+  recorded_at: Fri, 09 Aug 2019 17:08:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_invalid_coords.yml
+++ b/spec/cassettes/public_face_area_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2019 16:31:58 GMT
+      - Fri, 09 Aug 2019 17:08:26 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 16:31:59 GMT
+  recorded_at: Fri, 09 Aug 2019 17:08:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_valid.yml
+++ b/spec/cassettes/public_face_area_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - environment.data.gov.uk
   response:
@@ -23,11 +23,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2019 16:31:58 GMT
+      - Fri, 09 Aug 2019 17:08:33 GMT
       Content-Type:
       - application/xml
       Content-Length:
-      - '1613'
+      - '1693'
       Connection:
       - keep-alive
       Cache-Control:
@@ -50,11 +50,13 @@ http_interactions:
             <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.23">
               <ms:OBJECTID>23</ms:OBJECTID>
               <ms:long_name>West Midlands</ms:long_name>
+              <ms:short_name>West Midlands</ms:short_name>
+              <ms:code>WMD</ms:code>
               <ms:st_area_shape_>14543741870.84492</ms:st_area_shape_>
               <ms:st_perimeter_shape_>1043376.795941756</ms:st_perimeter_shape_>
             </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 16:31:58 GMT
+  recorded_at: Fri, 09 Aug 2019 17:08:34 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_blank.yml
+++ b/spec/cassettes/water_management_area_invalid_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2019 16:31:54 GMT
+      - Fri, 09 Aug 2019 17:08:21 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 16:31:54 GMT
+  recorded_at: Fri, 09 Aug 2019 17:08:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_coords.yml
+++ b/spec/cassettes/water_management_area_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2019 16:31:57 GMT
+      - Fri, 09 Aug 2019 17:08:14 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 16:31:57 GMT
+  recorded_at: Fri, 09 Aug 2019 17:08:14 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_valid.yml
+++ b/spec/cassettes/water_management_area_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=long_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - environment.data.gov.uk
   response:
@@ -23,11 +23,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 05 Aug 2019 16:31:57 GMT
+      - Fri, 09 Aug 2019 17:08:14 GMT
       Content-Type:
       - application/xml
       Content-Length:
-      - '1434'
+      - '1530'
       Connection:
       - keep-alive
       Cache-Control:
@@ -50,11 +50,13 @@ http_interactions:
             <ms:Administrative_Boundaries_Water_Management_Areas fid="Administrative_Boundaries_Water_Management_Areas.15">
               <ms:OBJECTID>15</ms:OBJECTID>
               <ms:long_name>Staffordshire Warwickshire and West Midlands</ms:long_name>
+              <ms:short_name>Staffs Warks and West Mids</ms:short_name>
+              <ms:code>STWKWM</ms:code>
               <ms:st_area_shape_>6460280400.1</ms:st_area_shape_>
               <ms:st_perimeter_shape_>759189.708848595</ms:st_perimeter_shape_>
             </ms:Administrative_Boundaries_Water_Management_Areas>
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 16:31:58 GMT
+  recorded_at: Fri, 09 Aug 2019 17:08:14 GMT
 recorded_with: VCR 4.0.0

--- a/spec/defra_ruby/area/area_spec.rb
+++ b/spec/defra_ruby/area/area_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module DefraRuby
+  module Area
+    RSpec.describe Area do
+      describe "#matched?" do
+        context "when no attributes are populated" do
+          let(:subject) { described_class.new(nil, nil, nil) }
+
+          it "returns false" do
+            expect(subject.matched?).to eq(false)
+          end
+        end
+      end
+
+      describe "#matched?" do
+        context "when at least one attribute is populated" do
+          let(:subject) { described_class.new("foo", nil, nil) }
+
+          it "returns true" do
+            expect(subject.matched?).to eq(true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/area/response_spec.rb
+++ b/spec/defra_ruby/area/response_spec.rb
@@ -6,7 +6,7 @@ module DefraRuby
   module Area
     RSpec.describe Response do
       subject(:response) { described_class.new(response_exe) }
-      let(:successful) { -> { { area: "Gallifrey" } } }
+      let(:successful) { -> { { area: Area.new("GFY", "Planet Gallifrey", "Gallifrey") } } }
       let(:errored) { -> { raise "Boom!" } }
 
       describe "#successful?" do
@@ -40,7 +40,8 @@ module DefraRuby
           let(:response_exe) { successful }
 
           it "returns an area" do
-            expect(response.area).to eq("Gallifrey")
+            expect(response.area).to be_instance_of(Area)
+            expect(response.area.short_name).to eq("Gallifrey")
           end
         end
       end

--- a/spec/defra_ruby/area/services/public_face_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/public_face_area_service_spec.rb
@@ -18,7 +18,7 @@ module DefraRuby
             response = described_class.run(easting, northing)
             expect(response).to be_a(Response)
             expect(response.successful?).to eq(true)
-            expect(response.area).to eq("West Midlands")
+            expect(response.area.long_name).to eq("West Midlands")
           end
 
         end

--- a/spec/defra_ruby/area/services/water_management_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/water_management_area_service_spec.rb
@@ -18,7 +18,7 @@ module DefraRuby
             response = described_class.run(easting, northing)
             expect(response).to be_a(Response)
             expect(response.successful?).to eq(true)
-            expect(response.area).to eq("Staffordshire Warwickshire and West Midlands")
+            expect(response.area.long_name).to eq("Staffordshire Warwickshire and West Midlands")
           end
 
         end


### PR DESCRIPTION
When we reviewed our existing services they only refer to the long name return by each of the administrative boundary Web Feature Services.

However when we initially went to implement this new gem with the [flood-risk-engine](https://github.com/Defra/flood-risk-engin) we found that it doesn't just update the registration with the long name. It instead creates a record (if one doesn't exist) in a separate table which it then links to the registration.

The object that gets saved to the table is expecting a code, short name and long name. We wanted to avoid doing too much refactoring in the flood-risk-engine as it has not gone through an alignment exercise.

So we've come back to this gem and updated how it works. Now `area` on `DefraRuby::Area::Response` will return an instance of `DefraRuby::Area::Area, which itself contains the code, short name and long name for an administrative area. This means we've also tweaked the query we send to the WFS's to include the additional parameters.