### PR TITLE
Add area ID to WFS request

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ response.error
 If the call is successful (the query did not error and a match was found) then
 
 - `successful?()` will be `true`
-- `area` will contain an instance of `DefraRuby::Area::Area`. It contains the code, short name and long name of the matching administrative boundary
+- `area` will contain an instance of `DefraRuby::Area::Area`. It contains the area ID, code, short name and long name of the matching administrative boundary
 - `error` will be `nil`
 
 If the call is unsuccessful (the query errored or no match was found) then

--- a/lib/defra_ruby/area/area.rb
+++ b/lib/defra_ruby/area/area.rb
@@ -3,16 +3,17 @@
 module DefraRuby
   module Area
     class Area
-      attr_reader :code, :long_name, :short_name
+      attr_reader :area_id, :code, :long_name, :short_name
 
-      def initialize(code, long_name, short_name)
+      def initialize(area_id, code, long_name, short_name)
+        @area_id = area_id
         @code = code
         @long_name = long_name
         @short_name = short_name
       end
 
       def matched?
-        "#{@code}#{@long_name}#{@short_name}" != ""
+        "#{@area_id}#{@code}#{@long_name}#{@short_name}" != ""
       end
 
     end

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -45,6 +45,7 @@ module DefraRuby
       def parse_xml(response)
         xml = Nokogiri::XML(response)
         Area.new(
+          xml.xpath(response_xml_path(:area_id)).text,
           xml.xpath(response_xml_path(:code)).text,
           xml.xpath(response_xml_path(:long_name)).text,
           xml.xpath(response_xml_path(:short_name)).text
@@ -133,7 +134,7 @@ module DefraRuby
       # properties, but we are only interested in +code+, +long_name+ and
       # +short_name+.
       def property_name
-        "code,long_name,short_name"
+        "area_id,code,long_name,short_name"
       end
 
       # SRS stands for Spatial Reference System. It can also be known as a

--- a/spec/cassettes/public_face_area_invalid_blank.yml
+++ b/spec/cassettes/public_face_area_invalid_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 09 Aug 2019 17:08:26 GMT
+      - Sun, 11 Aug 2019 09:41:21 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Fri, 09 Aug 2019 17:08:26 GMT
+  recorded_at: Sun, 11 Aug 2019 09:41:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_invalid_coords.yml
+++ b/spec/cassettes/public_face_area_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 09 Aug 2019 17:08:26 GMT
+      - Sun, 11 Aug 2019 09:41:21 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Fri, 09 Aug 2019 17:08:26 GMT
+  recorded_at: Sun, 11 Aug 2019 09:41:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_valid.yml
+++ b/spec/cassettes/public_face_area_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 09 Aug 2019 17:08:33 GMT
+      - Sun, 11 Aug 2019 09:41:22 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -58,5 +58,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Fri, 09 Aug 2019 17:08:34 GMT
+  recorded_at: Sun, 11 Aug 2019 09:41:22 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_blank.yml
+++ b/spec/cassettes/water_management_area_invalid_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 09 Aug 2019 17:08:21 GMT
+      - Sun, 11 Aug 2019 09:41:20 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Fri, 09 Aug 2019 17:08:21 GMT
+  recorded_at: Sun, 11 Aug 2019 09:41:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_coords.yml
+++ b/spec/cassettes/water_management_area_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 09 Aug 2019 17:08:14 GMT
+      - Sun, 11 Aug 2019 09:41:20 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Fri, 09 Aug 2019 17:08:14 GMT
+  recorded_at: Sun, 11 Aug 2019 09:41:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_valid.yml
+++ b/spec/cassettes/water_management_area_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,11 +23,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 09 Aug 2019 17:08:14 GMT
+      - Sun, 11 Aug 2019 09:41:21 GMT
       Content-Type:
       - application/xml
       Content-Length:
-      - '1530'
+      - '1564'
       Connection:
       - keep-alive
       Cache-Control:
@@ -52,11 +52,12 @@ http_interactions:
               <ms:long_name>Staffordshire Warwickshire and West Midlands</ms:long_name>
               <ms:short_name>Staffs Warks and West Mids</ms:short_name>
               <ms:code>STWKWM</ms:code>
+              <ms:area_id>29</ms:area_id>
               <ms:st_area_shape_>6460280400.1</ms:st_area_shape_>
               <ms:st_perimeter_shape_>759189.708848595</ms:st_perimeter_shape_>
             </ms:Administrative_Boundaries_Water_Management_Areas>
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Fri, 09 Aug 2019 17:08:14 GMT
+  recorded_at: Sun, 11 Aug 2019 09:41:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/defra_ruby/area/area_spec.rb
+++ b/spec/defra_ruby/area/area_spec.rb
@@ -7,7 +7,7 @@ module DefraRuby
     RSpec.describe Area do
       describe "#matched?" do
         context "when no attributes are populated" do
-          let(:subject) { described_class.new(nil, nil, nil) }
+          let(:subject) { described_class.new(nil, nil, nil, nil) }
 
           it "returns false" do
             expect(subject.matched?).to eq(false)
@@ -17,7 +17,7 @@ module DefraRuby
 
       describe "#matched?" do
         context "when at least one attribute is populated" do
-          let(:subject) { described_class.new("foo", nil, nil) }
+          let(:subject) { described_class.new(nil, "foo", nil, nil) }
 
           it "returns true" do
             expect(subject.matched?).to eq(true)

--- a/spec/defra_ruby/area/response_spec.rb
+++ b/spec/defra_ruby/area/response_spec.rb
@@ -6,7 +6,7 @@ module DefraRuby
   module Area
     RSpec.describe Response do
       subject(:response) { described_class.new(response_exe) }
-      let(:successful) { -> { { area: Area.new("GFY", "Planet Gallifrey", "Gallifrey") } } }
+      let(:successful) { -> { { area: Area.new(16, "GFY", "Planet Gallifrey", "Gallifrey") } } }
       let(:errored) { -> { raise "Boom!" } }
 
       describe "#successful?" do


### PR DESCRIPTION
Further reviews of the existing code has identified more data being requested of the administrative boundaries.

We have also found that area ID and area name is requested. This is the first of 2 changes to add them. This change adds area ID to the request and handles the result.