### PR TITLE
Refactor Area to parse the WFS XML response

### DIFF
--- a/lib/defra_ruby/area/area.rb
+++ b/lib/defra_ruby/area/area.rb
@@ -1,19 +1,41 @@
 # frozen_string_literal: true
 
+require "nokogiri"
+
 module DefraRuby
   module Area
     class Area
       attr_reader :area_id, :code, :long_name, :short_name
 
-      def initialize(area_id, code, long_name, short_name)
-        @area_id = area_id
-        @code = code
-        @long_name = long_name
-        @short_name = short_name
+      def initialize(type_name, wfs_xml_response)
+        @type_name = type_name
+        @xml = wfs_xml_response
+
+        validate
+        parse_xml
       end
 
       def matched?
-        "#{@area_id}#{@code}#{@long_name}#{@short_name}" != ""
+        "#{@code}#{@long_name}#{@short_name}" != ""
+      end
+
+      private
+
+      def validate
+        raise(ArgumentError, "type_name is invalid") unless @type_name && @type_name != ""
+        raise(ArgumentError, "wfs_xml_response is invalid") unless @xml && @xml.is_a?(Nokogiri::XML::Document)
+      end
+
+      def parse_xml
+        @area_id = @xml.xpath(response_xml_path(:area_id)).text.to_i
+        @code = @xml.xpath(response_xml_path(:code)).text
+        @long_name = @xml.xpath(response_xml_path(:long_name)).text
+        @short_name = @xml.xpath(response_xml_path(:short_name)).text
+      end
+
+      # XML path to the value we wish to extract in the WFS query response.
+      def response_xml_path(property)
+        "//wfs:FeatureCollection/gml:featureMember/#{@type_name}/ms:#{property}"
       end
 
     end

--- a/lib/defra_ruby/area/area.rb
+++ b/lib/defra_ruby/area/area.rb
@@ -22,8 +22,16 @@ module DefraRuby
       private
 
       def validate
+        validate_type_name
+        validate_xml
+      end
+
+      def validate_type_name
         raise(ArgumentError, "type_name is invalid") unless @type_name && @type_name != ""
-        raise(ArgumentError, "wfs_xml_response is invalid") unless @xml && @xml.is_a?(Nokogiri::XML::Document)
+      end
+
+      def validate_xml
+        raise(ArgumentError, "wfs_xml_response is invalid") unless @xml&.is_a?(Nokogiri::XML::Document)
       end
 
       def parse_xml

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "nokogiri"
 require "rest-client"
 
 module DefraRuby
@@ -31,7 +30,7 @@ module DefraRuby
             url: url,
             timeout: DefraRuby::Area.configuration.timeout
           )
-          area = parse_xml(response)
+          area = Area.new(type_name, Nokogiri::XML(response))
           raise NoMatchError unless area.matched?
 
           { area: area }
@@ -40,21 +39,6 @@ module DefraRuby
 
       def url
         "#{domain}/spatialdata/#{dataset}/wfs?#{url_params}"
-      end
-
-      def parse_xml(response)
-        xml = Nokogiri::XML(response)
-        Area.new(
-          xml.xpath(response_xml_path(:area_id)).text,
-          xml.xpath(response_xml_path(:code)).text,
-          xml.xpath(response_xml_path(:long_name)).text,
-          xml.xpath(response_xml_path(:short_name)).text
-        )
-      end
-
-      # XML path to the value we wish to extract in the WFS query response.
-      def response_xml_path(property)
-        "//wfs:FeatureCollection/gml:featureMember/#{type_name}/ms:#{property}"
       end
 
       # Domain where the WFS is hosted

--- a/spec/defra_ruby/area/area_spec.rb
+++ b/spec/defra_ruby/area/area_spec.rb
@@ -1,26 +1,108 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "nokogiri"
 
 module DefraRuby
   module Area
     RSpec.describe Area do
-      describe "#matched?" do
-        context "when no attributes are populated" do
-          let(:subject) { described_class.new(nil, nil, nil, nil) }
+      let(:valid_type_name) { "ms:Administrative_Boundaries_Water_Management_Areas" }
+      let(:invalid_type_name) { "////" }
+      let(:no_match_type_name) { "ms:Marvel_Cinematic_Universe_Areas" }
 
-          it "returns false" do
-            expect(subject.matched?).to eq(false)
+      let(:valid_xml) { File.open("spec/fixtures/valid.xml") { |f| Nokogiri::XML(f) } }
+      let(:invalid_xml) { "foo" }
+      let(:no_match_xml) { File.open("spec/fixtures/no_match.xml") { |f| Nokogiri::XML(f) } }
+
+      let(:no_match_area) { described_class.new(valid_type_name, no_match_xml) }
+      let(:matched_area) { described_class.new(valid_type_name, valid_xml) }
+
+      describe "#initialize" do
+        context "when arguments are missing" do
+
+          context "and both arguments are missing" do
+            it "raises an ArgumentError" do
+              expect { described_class.new(nil, nil) }.to raise_error(ArgumentError, "type_name is invalid")
+            end
+          end
+
+          context "and `type_name` is missing" do
+            it "raises an ArgumentError" do
+              expect { described_class.new(nil, valid_xml) }.to raise_error(ArgumentError, "type_name is invalid")
+            end
+          end
+
+          context "and `wfs_xml_response` is missing" do
+            it "raises an ArgumentError" do
+              expect { described_class.new(valid_type_name, nil) }.to raise_error(ArgumentError, "wfs_xml_response is invalid")
+            end
+          end
+        end
+
+        context "when arguments are invalid" do
+
+          context "and passed an invalid Nokogiri::XML::Documentation instance" do
+            it "raises an error" do
+              expect { described_class.new(valid_type_name, invalid_xml) }.to raise_error(ArgumentError, "wfs_xml_response is invalid")
+            end
+          end
+
+          context "and passed an invalid type name" do
+            it "raises an error" do
+              expect { described_class.new(invalid_type_name, valid_xml) }.to raise_error(Nokogiri::XML::XPath::SyntaxError)
+            end
+          end
+        end
+
+        context "when passed valid arguments" do
+
+          context "and type name is recognised and there was a match" do
+            it "populates all an Area's attributes" do
+              subject = described_class.new(valid_type_name, valid_xml)
+
+              expect(subject.area_id).to eq(29)
+              expect(subject.code).to eq("STWKWM")
+              expect(subject.short_name).to eq("Staffs Warks and West Mids")
+              expect(subject.long_name).to eq("Staffordshire Warwickshire and West Midlands")
+            end
+          end
+
+          context "and type name does not match the xml" do
+            it "does not populate an Area's attributes" do
+              subject = described_class.new(no_match_type_name, valid_xml)
+
+              expect(subject.area_id).to eq(0)
+              expect(subject.code).to eq("")
+              expect(subject.short_name).to eq("")
+              expect(subject.long_name).to eq("")
+            end
+          end
+
+          context "and the WFS responded with no match" do
+            it "does not populate an Area's attributes" do
+              subject = described_class.new(valid_type_name, no_match_xml)
+
+              expect(subject.area_id).to eq(0)
+              expect(subject.code).to eq("")
+              expect(subject.short_name).to eq("")
+              expect(subject.long_name).to eq("")
+            end
           end
         end
       end
 
       describe "#matched?" do
-        context "when at least one attribute is populated" do
-          let(:subject) { described_class.new(nil, "foo", nil, nil) }
+        context "when no match was found" do
+
+          it "returns false" do
+            expect(no_match_area.matched?).to eq(false)
+          end
+        end
+
+        context "when a match was found" do
 
           it "returns true" do
-            expect(subject.matched?).to eq(true)
+            expect(matched_area.matched?).to eq(true)
           end
         end
       end

--- a/spec/defra_ruby/area/response_spec.rb
+++ b/spec/defra_ruby/area/response_spec.rb
@@ -6,7 +6,11 @@ module DefraRuby
   module Area
     RSpec.describe Response do
       subject(:response) { described_class.new(response_exe) }
-      let(:successful) { -> { { area: Area.new(16, "GFY", "Planet Gallifrey", "Gallifrey") } } }
+
+      let(:valid_type_name) { "ms:Administrative_Boundaries_Water_Management_Areas" }
+      let(:valid_xml) { File.open("spec/fixtures/valid.xml") { |f| Nokogiri::XML(f) } }
+
+      let(:successful) { -> { { area: Area.new(valid_type_name, valid_xml) } } }
       let(:errored) { -> { raise "Boom!" } }
 
       describe "#successful?" do
@@ -18,7 +22,7 @@ module DefraRuby
           end
         end
 
-        context "when the response don't throw an error" do
+        context "when the response doesn't throw an error" do
           let(:response_exe) { successful }
 
           it "returns true" do
@@ -41,7 +45,7 @@ module DefraRuby
 
           it "returns an area" do
             expect(response.area).to be_instance_of(Area)
-            expect(response.area.short_name).to eq("Gallifrey")
+            expect(response.area.short_name).to eq("Staffs Warks and West Mids")
           end
         end
       end

--- a/spec/fixtures/no_match.xml
+++ b/spec/fixtures/no_match.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+<gml:boundedBy>
+  <gml:Box srsName="EPSG:27700">
+    <gml:coordinates>0,0,0,0</gml:coordinates>
+  </gml:Box>
+</gml:boundedBy>
+</wfs:FeatureCollection>

--- a/spec/fixtures/valid.xml
+++ b/spec/fixtures/valid.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+<gml:boundedBy>
+  <gml:Box srsName="EPSG:27700">
+    <gml:coordinates>0,0,0,0</gml:coordinates>
+  </gml:Box>
+</gml:boundedBy>
+  <gml:featureMember>
+    <ms:Administrative_Boundaries_Water_Management_Areas fid="Administrative_Boundaries_Water_Management_Areas.15">
+      <ms:OBJECTID>15</ms:OBJECTID>
+      <ms:long_name>Staffordshire Warwickshire and West Midlands</ms:long_name>
+      <ms:short_name>Staffs Warks and West Mids</ms:short_name>
+      <ms:code>STWKWM</ms:code>
+      <ms:area_id>29</ms:area_id>
+      <ms:st_area_shape_>6460280400.1</ms:st_area_shape_>
+      <ms:st_perimeter_shape_>759189.708848595</ms:st_perimeter_shape_>
+    </ms:Administrative_Boundaries_Water_Management_Areas>
+  </gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
Having added the property `area_id` to the `DefraRuby::Area::Area` class we've hit the general rule that "pass no more than four parameters into a method". We know we need to add `area_name` in our next change, at which point we'll break the rule and rubocop will start to complain.

We could override rubocop as it would just be this one instance, but we decided instead to refactor as per [Preserve Whole Object](https://refactoring.guru/preserve-whole-object).

The [rule comes from Sandi Metz](https://thoughtbot.com/blog/sandi-metz-rules-for-developers) author of **Practical Object-Oriented Design in Ruby**. She's also stated that "you can’t just make it one big hash."

The **perservce whole object refactor** is

> **Problem** You get several values from an object and then pass them as parameters to a method.
> **Solution** Instead, try passing the whole object.

So rather than have the `BaseService` parse the xml for the values and pass them to the `Area` instance, we've refactored it such that the parsing of the XML is now handled by the `Area` class. The `BaseService` just passes what the `Area` instance needs to do this.

With this change we'll be ready to handle adding the area name as an attribute.