### PR TITLE
Add area name to WFS request and response

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ response.error
 If the call is successful (the query did not error and a match was found) then
 
 - `successful?()` will be `true`
-- `area` will contain an instance of `DefraRuby::Area::Area`. It contains the area ID, code, short name and long name of the matching administrative boundary
+- `area` will contain an instance of `DefraRuby::Area::Area`. It contains the area ID, area name, code, short name and long name of the matching administrative boundary
 - `error` will be `nil`
 
 If the call is unsuccessful (the query errored or no match was found) then

--- a/lib/defra_ruby/area/area.rb
+++ b/lib/defra_ruby/area/area.rb
@@ -5,7 +5,7 @@ require "nokogiri"
 module DefraRuby
   module Area
     class Area
-      attr_reader :area_id, :code, :long_name, :short_name
+      attr_reader :area_id, :area_name, :code, :long_name, :short_name
 
       def initialize(type_name, wfs_xml_response)
         @type_name = type_name
@@ -16,7 +16,7 @@ module DefraRuby
       end
 
       def matched?
-        "#{@code}#{@long_name}#{@short_name}" != ""
+        "#{@area_name}#{@code}#{@long_name}#{@short_name}" != ""
       end
 
       private
@@ -36,6 +36,7 @@ module DefraRuby
 
       def parse_xml
         @area_id = @xml.xpath(response_xml_path(:area_id)).text.to_i
+        @area_name = @xml.xpath(response_xml_path(:area_name)).text
         @code = @xml.xpath(response_xml_path(:code)).text
         @long_name = @xml.xpath(response_xml_path(:long_name)).text
         @short_name = @xml.xpath(response_xml_path(:short_name)).text

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -115,10 +115,16 @@ module DefraRuby
       # https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=DescribeFeatureType
       #
       # In our case the administrative boundary features contain a number of
-      # properties, but we are only interested in +code+, +long_name+ and
-      # +short_name+.
+      # properties, but we are only interested in
+      #
+      # - +area_id+
+      # - +area_name+
+      # - +code+
+      # - +long_name+
+      # - +short_name+
+      #
       def property_name
-        "area_id,code,long_name,short_name"
+        "area_id,area_name,code,long_name,short_name"
       end
 
       # SRS stands for Spatial Reference System. It can also be known as a

--- a/spec/cassettes/public_face_area_invalid_blank.yml
+++ b/spec/cassettes/public_face_area_invalid_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 09:41:21 GMT
+      - Sun, 11 Aug 2019 15:53:34 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 09:41:21 GMT
+  recorded_at: Sun, 11 Aug 2019 15:53:34 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_invalid_coords.yml
+++ b/spec/cassettes/public_face_area_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 09:41:21 GMT
+      - Sun, 11 Aug 2019 15:53:33 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 09:41:21 GMT
+  recorded_at: Sun, 11 Aug 2019 15:53:34 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_valid.yml
+++ b/spec/cassettes/public_face_area_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 09:41:22 GMT
+      - Sun, 11 Aug 2019 15:53:27 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -58,5 +58,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 09:41:22 GMT
+  recorded_at: Sun, 11 Aug 2019 15:53:28 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_blank.yml
+++ b/spec/cassettes/water_management_area_invalid_blank.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E,%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 09:41:20 GMT
+      - Sun, 11 Aug 2019 15:53:35 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 09:41:20 GMT
+  recorded_at: Sun, 11 Aug 2019 15:53:35 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_coords.yml
+++ b/spec/cassettes/water_management_area_invalid_coords.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E301233.0,221592.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 09:41:20 GMT
+      - Sun, 11 Aug 2019 15:53:34 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 09:41:20 GMT
+  recorded_at: Sun, 11 Aug 2019 15:53:34 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_valid.yml
+++ b/spec/cassettes/water_management_area_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E408602.61,257535.31%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
     body:
       encoding: US-ASCII
       string: ''
@@ -23,11 +23,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 09:41:21 GMT
+      - Sun, 11 Aug 2019 15:53:41 GMT
       Content-Type:
       - application/xml
       Content-Length:
-      - '1564'
+      - '1607'
       Connection:
       - keep-alive
       Cache-Control:
@@ -53,11 +53,12 @@ http_interactions:
               <ms:short_name>Staffs Warks and West Mids</ms:short_name>
               <ms:code>STWKWM</ms:code>
               <ms:area_id>29</ms:area_id>
+              <ms:area_name>Central</ms:area_name>
               <ms:st_area_shape_>6460280400.1</ms:st_area_shape_>
               <ms:st_perimeter_shape_>759189.708848595</ms:st_perimeter_shape_>
             </ms:Administrative_Boundaries_Water_Management_Areas>
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 09:41:21 GMT
+  recorded_at: Sun, 11 Aug 2019 15:53:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/defra_ruby/area/area_spec.rb
+++ b/spec/defra_ruby/area/area_spec.rb
@@ -61,6 +61,7 @@ module DefraRuby
               subject = described_class.new(valid_type_name, valid_xml)
 
               expect(subject.area_id).to eq(29)
+              expect(subject.area_name).to eq("Central")
               expect(subject.code).to eq("STWKWM")
               expect(subject.short_name).to eq("Staffs Warks and West Mids")
               expect(subject.long_name).to eq("Staffordshire Warwickshire and West Midlands")
@@ -72,6 +73,7 @@ module DefraRuby
               subject = described_class.new(no_match_type_name, valid_xml)
 
               expect(subject.area_id).to eq(0)
+              expect(subject.area_name).to eq("")
               expect(subject.code).to eq("")
               expect(subject.short_name).to eq("")
               expect(subject.long_name).to eq("")
@@ -83,6 +85,7 @@ module DefraRuby
               subject = described_class.new(valid_type_name, no_match_xml)
 
               expect(subject.area_id).to eq(0)
+              expect(subject.area_name).to eq("")
               expect(subject.code).to eq("")
               expect(subject.short_name).to eq("")
               expect(subject.long_name).to eq("")

--- a/spec/fixtures/valid.xml
+++ b/spec/fixtures/valid.xml
@@ -12,6 +12,7 @@
       <ms:short_name>Staffs Warks and West Mids</ms:short_name>
       <ms:code>STWKWM</ms:code>
       <ms:area_id>29</ms:area_id>
+      <ms:area_name>Central</ms:area_name>
       <ms:st_area_shape_>6460280400.1</ms:st_area_shape_>
       <ms:st_perimeter_shape_>759189.708848595</ms:st_perimeter_shape_>
     </ms:Administrative_Boundaries_Water_Management_Areas>


### PR DESCRIPTION
As stated in PR #7 we need to capture some additional information from the Web Feature Service before we can complete the switchover of FRAE to the new gem.

This adds the final property, the area name.