### PR TITLE
Add support for multiple WFS results

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Gem Version](https://badge.fury.io/rb/defra_ruby_area.svg)](https://badge.fury.io/rb/defra_ruby_area)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
-This ruby gem provides a means of looking up an Environment Agency Administrative boundary area from a GIS Web Feature Service (WFS). Provided with a valid [easting and northing](https://en.wikipedia.org/wiki/Easting_and_northing) it will query the WFS and return various properties for the matching area found.
+This ruby gem provides a means of looking up Environment Agency Administrative boundary areas from a GIS Web Feature Service (WFS). Provided with a valid [easting and northing](https://en.wikipedia.org/wiki/Easting_and_northing) it will query the WFS and return various properties for each matching area found.
 
 ## Installation
 
@@ -46,7 +46,7 @@ If the call is successful then
 If the call is unsuccessful (the query errored or no match was found) then
 
 - `successful?()` will be `false`
-- `areas` will be `nil`
+- `areas` will be `[]` (an empty array)
 - `error` will contain the error
 
 If it's a runtime error, or an error when calling the WFS `error` will contain whatever error was raised.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Gem Version](https://badge.fury.io/rb/defra_ruby_area.svg)](https://badge.fury.io/rb/defra_ruby_area)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
-This ruby gem provides a means of looking up an Environment Agency Administrative boundary area from a GIS Web Feature Service (WFS). Provided with a valid [easting and northing](https://en.wikipedia.org/wiki/Easting_and_northing) it will query the WFS and return the various properties for the area if a match is found.
+This ruby gem provides a means of looking up an Environment Agency Administrative boundary area from a GIS Web Feature Service (WFS). Provided with a valid [easting and northing](https://en.wikipedia.org/wiki/Easting_and_northing) it will query the WFS and return various properties for the matching area found.
 
 ## Installation
 
@@ -33,20 +33,20 @@ Each WFS is called through a service that responds with a `DefraRuby::Area::Resp
 
 ```ruby
 response.successful?
-response.area
+response.areas
 response.error
 ```
 
-If the call is successful (the query did not error and a match was found) then
+If the call is successful then
 
 - `successful?()` will be `true`
-- `area` will contain an instance of `DefraRuby::Area::Area`. It contains the area ID, area name, code, short name and long name of the matching administrative boundary
+- `areas` will contain an array of `DefraRuby::Area::Area`. Each contains the area ID, area name, code, short name and long name of the matching administrative boundary
 - `error` will be `nil`
 
 If the call is unsuccessful (the query errored or no match was found) then
 
 - `successful?()` will be `false`
-- `area` will be `nil`
+- `areas` will be `nil`
 - `error` will contain the error
 
 If it's a runtime error, or an error when calling the WFS `error` will contain whatever error was raised.
@@ -62,7 +62,7 @@ easting = 408_602.61
 northing = 257_535.31
 response = DefraRuby::Area::PublicFaceAreaService.run(easting, northing)
 
-puts response.area.long_name if response.successful? # West Midlands
+puts response.areas.first.long_name if response.successful? # West Midlands
 ```
 
 ### Water Management Areas
@@ -74,8 +74,17 @@ easting = 408_602.61
 northing = 257_535.31
 response = DefraRuby::Area::WaterManagementAreaService.run(easting, northing)
 
-puts response.area.long_name if response.successful? # Staffordshire Warwickshire and West Midlands
+puts response.areas.first.long_name if response.successful? # Staffordshire Warwickshire and West Midlands
 ```
+
+### Multiple results
+
+In most cases we expect `response.areas` to contain a single result. It is possible though for a given easting and northing to return multiple administrative boundary areas. Where we see this is when a coordinate is on the boundary of 2 areas. This is why **defra-ruby-area** is setup to return multiple results.
+
+Examples:
+
+- **Public face areas** easting = `398056.684` and northing = `414748` (*Yorkshire* and *Greater Manchester Merseyside and Cheshire*)
+- **Water management areas** easting = `456330` and northing = `267000` (*Lincolnshire and Northamptonshire* and *Staffordshire Warwickshire and West Midlands*)
 
 ## Web Feature Services
 

--- a/lib/defra_ruby/area/area.rb
+++ b/lib/defra_ruby/area/area.rb
@@ -7,44 +7,25 @@ module DefraRuby
     class Area
       attr_reader :area_id, :area_name, :code, :long_name, :short_name
 
-      def initialize(type_name, wfs_xml_response)
-        @type_name = type_name
-        @xml = wfs_xml_response
+      def initialize(wfs_xml_element)
+        @xml = wfs_xml_element
 
-        validate
+        validate_xml
         parse_xml
-      end
-
-      def matched?
-        "#{@area_name}#{@code}#{@long_name}#{@short_name}" != ""
       end
 
       private
 
-      def validate
-        validate_type_name
-        validate_xml
-      end
-
-      def validate_type_name
-        raise(ArgumentError, "type_name is invalid") unless @type_name && @type_name != ""
-      end
-
       def validate_xml
-        raise(ArgumentError, "wfs_xml_response is invalid") unless @xml&.is_a?(Nokogiri::XML::Document)
+        raise(ArgumentError, "wfs_xml_element is invalid") unless @xml&.is_a?(Nokogiri::XML::Element)
       end
 
       def parse_xml
-        @area_id = @xml.xpath(response_xml_path(:area_id)).text.to_i
-        @area_name = @xml.xpath(response_xml_path(:area_name)).text
-        @code = @xml.xpath(response_xml_path(:code)).text
-        @long_name = @xml.xpath(response_xml_path(:long_name)).text
-        @short_name = @xml.xpath(response_xml_path(:short_name)).text
-      end
-
-      # XML path to the value we wish to extract in the WFS query response.
-      def response_xml_path(property)
-        "//wfs:FeatureCollection/gml:featureMember/#{@type_name}/ms:#{property}"
+        @area_id = @xml.xpath("ms:area_id").text.to_i
+        @area_name = @xml.xpath("ms:area_name").text
+        @code = @xml.xpath("ms:code").text
+        @long_name = @xml.xpath("ms:long_name").text
+        @short_name = @xml.xpath("ms:short_name").text
       end
 
     end

--- a/lib/defra_ruby/area/response.rb
+++ b/lib/defra_ruby/area/response.rb
@@ -25,6 +25,7 @@ module DefraRuby
       def capture_response(response_exe)
         @areas = response_exe.call[:areas]
       rescue StandardError => e
+        @areas = []
         @error = e
         @success = false
       end

--- a/lib/defra_ruby/area/response.rb
+++ b/lib/defra_ruby/area/response.rb
@@ -4,11 +4,11 @@ module DefraRuby
   module Area
     class Response
       attr_reader :error
-      attr_reader :area
+      attr_reader :areas
 
       def initialize(response_exe)
         @success = true
-        @area = nil
+        @areas = nil
         @error = nil
 
         capture_response(response_exe)
@@ -23,7 +23,7 @@ module DefraRuby
       attr_reader :success
 
       def capture_response(response_exe)
-        @area = response_exe.call[:area]
+        @areas = response_exe.call[:areas]
       rescue StandardError => e
         @error = e
         @success = false

--- a/lib/defra_ruby/area/response.rb
+++ b/lib/defra_ruby/area/response.rb
@@ -8,7 +8,7 @@ module DefraRuby
 
       def initialize(response_exe)
         @success = true
-        @areas = nil
+        @areas = []
         @error = nil
 
         capture_response(response_exe)
@@ -25,7 +25,6 @@ module DefraRuby
       def capture_response(response_exe)
         @areas = response_exe.call[:areas]
       rescue StandardError => e
-        @areas = []
         @error = e
         @success = false
       end

--- a/lib/defra_ruby/area/services/base_area_service.rb
+++ b/lib/defra_ruby/area/services/base_area_service.rb
@@ -30,11 +30,21 @@ module DefraRuby
             url: url,
             timeout: DefraRuby::Area.configuration.timeout
           )
-          area = Area.new(type_name, Nokogiri::XML(response))
-          raise NoMatchError unless area.matched?
+          areas = extract_areas(Nokogiri::XML(response))
 
-          { area: area }
+          raise NoMatchError unless areas.any?
+
+          { areas: areas }
         end
+      end
+
+      def extract_areas(xml_response)
+        areas = []
+        xml_response.xpath("//wfs:FeatureCollection/gml:featureMember").each do |parent|
+          areas << Area.new(parent.first_element_child)
+        end
+
+        areas
       end
 
       def url

--- a/spec/cassettes/public_face_area_valid_multiple.yml
+++ b/spec/cassettes/public_face_area_valid_multiple.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E398056.684,414748%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 29 Aug 2019 09:52:19 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '2348'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.19">
+              <ms:OBJECTID>19</ms:OBJECTID>
+              <ms:long_name>Yorkshire</ms:long_name>
+              <ms:short_name>Yorkshire</ms:short_name>
+              <ms:code>YOR</ms:code>
+              <ms:st_area_shape_>14482874597.24499</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>820401.3233851442</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.20">
+              <ms:OBJECTID>20</ms:OBJECTID>
+              <ms:long_name>Greater Manchester Merseyside and Cheshire</ms:long_name>
+              <ms:short_name>Gtr Mancs Mersey and Ches</ms:short_name>
+              <ms:code>GMC</ms:code>
+              <ms:st_area_shape_>4473822349.59001</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>543689.9446941023</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 09:52:19 GMT
+recorded_with: VCR 4.0.0

--- a/spec/defra_ruby/area/area_spec.rb
+++ b/spec/defra_ruby/area/area_spec.rb
@@ -6,109 +6,41 @@ require "nokogiri"
 module DefraRuby
   module Area
     RSpec.describe Area do
-      let(:valid_type_name) { "ms:Administrative_Boundaries_Water_Management_Areas" }
-      let(:invalid_type_name) { "////" }
-      let(:no_match_type_name) { "ms:Marvel_Cinematic_Universe_Areas" }
-
-      let(:valid_xml) { File.open("spec/fixtures/valid.xml") { |f| Nokogiri::XML(f) } }
+      let(:valid_xml) do
+        document = Nokogiri::XML(File.read("spec/fixtures/valid.xml"))
+        document.xpath("//wfs:FeatureCollection/gml:featureMember").first.first_element_child
+      end
       let(:invalid_xml) { "foo" }
-      let(:no_match_xml) { File.open("spec/fixtures/no_match.xml") { |f| Nokogiri::XML(f) } }
 
-      let(:no_match_area) { described_class.new(valid_type_name, no_match_xml) }
-      let(:matched_area) { described_class.new(valid_type_name, valid_xml) }
+      let(:no_match_area) { described_class.new(no_match_xml) }
+      let(:matched_area) { described_class.new(valid_xml) }
 
       describe "#initialize" do
-        context "when arguments are missing" do
-
-          context "and both arguments are missing" do
-            it "raises an ArgumentError" do
-              expect { described_class.new(nil, nil) }.to raise_error(ArgumentError, "type_name is invalid")
-            end
-          end
-
-          context "and `type_name` is missing" do
-            it "raises an ArgumentError" do
-              expect { described_class.new(nil, valid_xml) }.to raise_error(ArgumentError, "type_name is invalid")
-            end
-          end
-
-          context "and `wfs_xml_response` is missing" do
-            it "raises an ArgumentError" do
-              expect { described_class.new(valid_type_name, nil) }.to raise_error(ArgumentError, "wfs_xml_response is invalid")
-            end
+        context "when `wfs_xml_element` is missing" do
+          it "raises an ArgumentError" do
+            expect { described_class.new(nil) }.to raise_error(ArgumentError, "wfs_xml_element is invalid")
           end
         end
 
-        context "when arguments are invalid" do
-
-          context "and passed an invalid Nokogiri::XML::Documentation instance" do
-            it "raises an error" do
-              expect { described_class.new(valid_type_name, invalid_xml) }.to raise_error(ArgumentError, "wfs_xml_response is invalid")
-            end
-          end
-
-          context "and passed an invalid type name" do
-            it "raises an error" do
-              expect { described_class.new(invalid_type_name, valid_xml) }.to raise_error(Nokogiri::XML::XPath::SyntaxError)
-            end
+        context "when `wfs_xml_element` is invalid" do
+          it "raises an error" do
+            expect { described_class.new(invalid_xml) }.to raise_error(ArgumentError, "wfs_xml_element is invalid")
           end
         end
 
-        context "when passed valid arguments" do
+        context "when `wfs_xml_element` is valid" do
+          it "populates all an Area's attributes" do
+            subject = described_class.new(valid_xml)
 
-          context "and type name is recognised and there was a match" do
-            it "populates all an Area's attributes" do
-              subject = described_class.new(valid_type_name, valid_xml)
-
-              expect(subject.area_id).to eq(29)
-              expect(subject.area_name).to eq("Central")
-              expect(subject.code).to eq("STWKWM")
-              expect(subject.short_name).to eq("Staffs Warks and West Mids")
-              expect(subject.long_name).to eq("Staffordshire Warwickshire and West Midlands")
-            end
-          end
-
-          context "and type name does not match the xml" do
-            it "does not populate an Area's attributes" do
-              subject = described_class.new(no_match_type_name, valid_xml)
-
-              expect(subject.area_id).to eq(0)
-              expect(subject.area_name).to eq("")
-              expect(subject.code).to eq("")
-              expect(subject.short_name).to eq("")
-              expect(subject.long_name).to eq("")
-            end
-          end
-
-          context "and the WFS responded with no match" do
-            it "does not populate an Area's attributes" do
-              subject = described_class.new(valid_type_name, no_match_xml)
-
-              expect(subject.area_id).to eq(0)
-              expect(subject.area_name).to eq("")
-              expect(subject.code).to eq("")
-              expect(subject.short_name).to eq("")
-              expect(subject.long_name).to eq("")
-            end
+            expect(subject.area_id).to eq(29)
+            expect(subject.area_name).to eq("Central")
+            expect(subject.code).to eq("STWKWM")
+            expect(subject.short_name).to eq("Staffs Warks and West Mids")
+            expect(subject.long_name).to eq("Staffordshire Warwickshire and West Midlands")
           end
         end
       end
 
-      describe "#matched?" do
-        context "when no match was found" do
-
-          it "returns false" do
-            expect(no_match_area.matched?).to eq(false)
-          end
-        end
-
-        context "when a match was found" do
-
-          it "returns true" do
-            expect(matched_area.matched?).to eq(true)
-          end
-        end
-      end
     end
   end
 end

--- a/spec/defra_ruby/area/area_spec.rb
+++ b/spec/defra_ruby/area/area_spec.rb
@@ -12,9 +12,6 @@ module DefraRuby
       end
       let(:invalid_xml) { "foo" }
 
-      let(:no_match_area) { described_class.new(no_match_xml) }
-      let(:matched_area) { described_class.new(valid_xml) }
-
       describe "#initialize" do
         context "when `wfs_xml_element` is missing" do
           it "raises an ArgumentError" do

--- a/spec/defra_ruby/area/response_spec.rb
+++ b/spec/defra_ruby/area/response_spec.rb
@@ -38,7 +38,7 @@ module DefraRuby
           let(:response_exe) { errored }
 
           it "returns nothing" do
-            expect(response.areas).to be_nil
+            expect(response.areas).to be_empty
           end
         end
 

--- a/spec/defra_ruby/area/response_spec.rb
+++ b/spec/defra_ruby/area/response_spec.rb
@@ -7,10 +7,12 @@ module DefraRuby
     RSpec.describe Response do
       subject(:response) { described_class.new(response_exe) }
 
-      let(:valid_type_name) { "ms:Administrative_Boundaries_Water_Management_Areas" }
-      let(:valid_xml) { File.open("spec/fixtures/valid.xml") { |f| Nokogiri::XML(f) } }
+      let(:valid_xml) do
+        document = Nokogiri::XML(File.read("spec/fixtures/valid.xml"))
+        document.xpath("//wfs:FeatureCollection/gml:featureMember").first.first_element_child
+      end
 
-      let(:successful) { -> { { area: Area.new(valid_type_name, valid_xml) } } }
+      let(:successful) { -> { { areas: [Area.new(valid_xml)] } } }
       let(:errored) { -> { raise "Boom!" } }
 
       describe "#successful?" do
@@ -36,7 +38,7 @@ module DefraRuby
           let(:response_exe) { errored }
 
           it "returns nothing" do
-            expect(response.area).to be_nil
+            expect(response.areas).to be_nil
           end
         end
 
@@ -44,8 +46,8 @@ module DefraRuby
           let(:response_exe) { successful }
 
           it "returns an area" do
-            expect(response.area).to be_instance_of(Area)
-            expect(response.area.short_name).to eq("Staffs Warks and West Mids")
+            expect(response.areas[0]).to be_instance_of(Area)
+            expect(response.areas[0].short_name).to eq("Staffs Warks and West Mids")
           end
         end
       end

--- a/spec/defra_ruby/area/services/public_face_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/public_face_area_service_spec.rb
@@ -50,7 +50,7 @@ module DefraRuby
               response = described_class.run(easting, northing)
               expect(response).to be_a(Response)
               expect(response).to_not be_successful
-              expect(response.areas).to be_nil
+              expect(response.areas).to be_empty
               expect(response.error).to_not be_nil
             end
           end
@@ -66,7 +66,7 @@ module DefraRuby
               response = described_class.run(easting, northing)
               expect(response).to be_a(Response)
               expect(response).to_not be_successful
-              expect(response.areas).to be_nil
+              expect(response.areas).to be_empty
               expect(response.error).to_not be_nil
             end
           end

--- a/spec/defra_ruby/area/services/public_face_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/public_face_area_service_spec.rb
@@ -18,9 +18,24 @@ module DefraRuby
             response = described_class.run(easting, northing)
             expect(response).to be_a(Response)
             expect(response.successful?).to eq(true)
-            expect(response.area.long_name).to eq("West Midlands")
+            expect(response.areas[0].long_name).to eq("West Midlands")
           end
 
+        end
+
+        context "when the coordinates are valid, in England but match more than one area" do
+          before(:each) { VCR.insert_cassette("public_face_area_valid_multiple") }
+          after(:each) { VCR.eject_cassette }
+
+          let(:easting) { 398_056.684 }
+          let(:northing) { 414_748 }
+
+          it "returns a successful response" do
+            response = described_class.run(easting, northing)
+            expect(response).to be_a(Response)
+            expect(response.successful?).to eq(true)
+            expect(response.areas[0].long_name).to eq("Yorkshire")
+          end
         end
 
         context "when the coordinates are invalid" do
@@ -35,7 +50,7 @@ module DefraRuby
               response = described_class.run(easting, northing)
               expect(response).to be_a(Response)
               expect(response).to_not be_successful
-              expect(response.area).to be_nil
+              expect(response.areas).to be_nil
               expect(response.error).to_not be_nil
             end
           end
@@ -51,7 +66,7 @@ module DefraRuby
               response = described_class.run(easting, northing)
               expect(response).to be_a(Response)
               expect(response).to_not be_successful
-              expect(response.area).to be_nil
+              expect(response.areas).to be_nil
               expect(response.error).to_not be_nil
             end
           end

--- a/spec/defra_ruby/area/services/water_management_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/water_management_area_service_spec.rb
@@ -18,9 +18,24 @@ module DefraRuby
             response = described_class.run(easting, northing)
             expect(response).to be_a(Response)
             expect(response.successful?).to eq(true)
-            expect(response.area.long_name).to eq("Staffordshire Warwickshire and West Midlands")
+            expect(response.areas[0].long_name).to eq("Staffordshire Warwickshire and West Midlands")
           end
 
+        end
+
+        context "when the coordinates are valid, in England but match more than one area" do
+          before(:each) { VCR.insert_cassette("water_management_area_valid_multiple") }
+          after(:each) { VCR.eject_cassette }
+
+          let(:easting) { 456_330 }
+          let(:northing) { 267_000 }
+
+          it "returns a successful response" do
+            response = described_class.run(easting, northing)
+            expect(response).to be_a(Response)
+            expect(response.successful?).to eq(true)
+            expect(response.areas[0].long_name).to eq("Lincolnshire and Northamptonshire")
+          end
         end
 
         context "when the coordinates are invalid" do
@@ -35,7 +50,7 @@ module DefraRuby
               response = described_class.run(easting, northing)
               expect(response).to be_a(Response)
               expect(response).to_not be_successful
-              expect(response.area).to be_nil
+              expect(response.areas).to be_nil
               expect(response.error).to_not be_nil
             end
           end
@@ -51,7 +66,7 @@ module DefraRuby
               response = described_class.run(easting, northing)
               expect(response).to be_a(Response)
               expect(response).to_not be_successful
-              expect(response.area).to be_nil
+              expect(response.areas).to be_nil
               expect(response.error).to_not be_nil
             end
           end

--- a/spec/defra_ruby/area/services/water_management_area_service_spec.rb
+++ b/spec/defra_ruby/area/services/water_management_area_service_spec.rb
@@ -50,7 +50,7 @@ module DefraRuby
               response = described_class.run(easting, northing)
               expect(response).to be_a(Response)
               expect(response).to_not be_successful
-              expect(response.areas).to be_nil
+              expect(response.areas).to be_empty
               expect(response.error).to_not be_nil
             end
           end
@@ -66,7 +66,7 @@ module DefraRuby
               response = described_class.run(easting, northing)
               expect(response).to be_a(Response)
               expect(response).to_not be_successful
-              expect(response.areas).to be_nil
+              expect(response.areas).to be_empty
               expect(response.error).to_not be_nil
             end
           end

--- a/spec/fixtures/no_match.xml
+++ b/spec/fixtures/no_match.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
-<gml:boundedBy>
-  <gml:Box srsName="EPSG:27700">
-    <gml:coordinates>0,0,0,0</gml:coordinates>
-  </gml:Box>
-</gml:boundedBy>
-</wfs:FeatureCollection>

--- a/spec/support/shared_examples/handle_request_errors.rb
+++ b/spec/support/shared_examples/handle_request_errors.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples "handle request errors" do
         response = described_class.run(easting, northing)
         expect(response).to be_a(DefraRuby::Area::Response)
         expect(response).to_not be_successful
-        expect(response.area).to be_nil
+        expect(response.areas).to be_nil
         expect(response.error).to_not be_nil
       end
     end
@@ -28,7 +28,7 @@ RSpec.shared_examples "handle request errors" do
         response = described_class.run(easting, northing)
         expect(response).to be_a(DefraRuby::Area::Response)
         expect(response).to_not be_successful
-        expect(response.area).to be_nil
+        expect(response.areas).to be_nil
         expect(response.error).to_not be_nil
       end
     end

--- a/spec/support/shared_examples/handle_request_errors.rb
+++ b/spec/support/shared_examples/handle_request_errors.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples "handle request errors" do
         response = described_class.run(easting, northing)
         expect(response).to be_a(DefraRuby::Area::Response)
         expect(response).to_not be_successful
-        expect(response.areas).to be_nil
+        expect(response.areas).to be_empty
         expect(response.error).to_not be_nil
       end
     end
@@ -28,7 +28,7 @@ RSpec.shared_examples "handle request errors" do
         response = described_class.run(easting, northing)
         expect(response).to be_a(DefraRuby::Area::Response)
         expect(response).to_not be_successful
-        expect(response.areas).to be_nil
+        expect(response.areas).to be_empty
         expect(response.error).to_not be_nil
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-484

When we originally integrated with the WFS's we were led to believe that because we were dealing with geospatial shapes that for any one query (coordinate) we would only get one matching administrative boundary.

However our awesome QA @andrewhick was able to find cases where a coordinate would return 2 boundaries.

Initially on the basis the functionality included in this gem is based on previous iterations which have been live for some years we were not intending to change the way things function. As such they would still continue to return the first result listed in the XML response.

In practise because of the way the XML parsing works in the gem, what actually happens is the values are getting concatenated. For example querying 456330 & 267000 returns **Lincolnshire and Northamptonshire** and **Staffordshire Warwickshire and West Midlands**. The resulting `long_name` for the area then becomes `"Lincolnshire and NorthamptonshireStaffordshire Warwickshire and West Midlands"`.

This happens for the all the values which is not acceptable. So we needed to update the way the XML parsing works to resolve it. And as we are refactoring that, we decided we may as well refactor the `DefraRuby::Area::Response` to return an array of all the results, not just the first. The calling app can then determine whether to just use the first result, or do something about using all the results.

Finally as we are now returning an array, we have made it so that in the event of an error or no match we return an empty array rather than `null`. This means the calling app knows it will always get an array, it's just whether it's populated or not.