### PR TITLE
Update minimum Nokogiri version to 1.10.4

### DIFF
--- a/defra_ruby_area.gemspec
+++ b/defra_ruby_area.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   # The response from the area WFS services is in XML so we need Nokogiri to
   # parse it
-  spec.add_dependency "nokogiri", "~> 1.10.3"
+  spec.add_dependency "nokogiri", "~> 1.10.4"
 
   # Use rest-client for external requests, eg. to Companies House
   spec.add_dependency "rest-client", "~> 2.0"

--- a/spec/cassettes/public_face_area_invalid_blank.yml
+++ b/spec/cassettes/public_face_area_invalid_blank.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 15:53:34 GMT
+      - Wed, 28 Aug 2019 22:48:25 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 15:53:34 GMT
+  recorded_at: Wed, 28 Aug 2019 22:48:25 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_invalid_coords.yml
+++ b/spec/cassettes/public_face_area_invalid_coords.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 15:53:33 GMT
+      - Wed, 28 Aug 2019 22:48:25 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 15:53:34 GMT
+  recorded_at: Wed, 28 Aug 2019 22:48:25 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/public_face_area_valid.yml
+++ b/spec/cassettes/public_face_area_valid.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 15:53:27 GMT
+      - Wed, 28 Aug 2019 22:48:25 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -58,5 +58,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 15:53:28 GMT
+  recorded_at: Wed, 28 Aug 2019 22:48:25 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_blank.yml
+++ b/spec/cassettes/water_management_area_invalid_blank.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 15:53:35 GMT
+      - Wed, 28 Aug 2019 22:48:26 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -45,5 +45,5 @@ http_interactions:
           <ogc:ServiceException><![CDATA[Operator 'Intersects' can't parse geometry.]]></ogc:ServiceException>
         </ogc:ServiceExceptionReport>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 15:53:35 GMT
+  recorded_at: Wed, 28 Aug 2019 22:48:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_invalid_coords.yml
+++ b/spec/cassettes/water_management_area_invalid_coords.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 15:53:34 GMT
+      - Wed, 28 Aug 2019 22:48:27 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -48,5 +48,5 @@ http_interactions:
         </gml:boundedBy>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 15:53:34 GMT
+  recorded_at: Wed, 28 Aug 2019 22:48:27 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_valid.yml
+++ b/spec/cassettes/water_management_area_valid.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - environment.data.gov.uk
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sun, 11 Aug 2019 15:53:41 GMT
+      - Wed, 28 Aug 2019 22:48:26 GMT
       Content-Type:
       - application/xml
       Content-Length:
@@ -60,5 +60,5 @@ http_interactions:
           </gml:featureMember>
         </wfs:FeatureCollection>
     http_version: 
-  recorded_at: Sun, 11 Aug 2019 15:53:41 GMT
+  recorded_at: Wed, 28 Aug 2019 22:48:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/water_management_area_valid_multiple.yml
+++ b/spec/cassettes/water_management_area_valid_multiple.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E456330,267000%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Water_Management_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 28 Aug 2019 16:25:23 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '2234'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-water-management-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Water_Management_Areas fid="Administrative_Boundaries_Water_Management_Areas.11">
+              <ms:OBJECTID>11</ms:OBJECTID>
+              <ms:long_name>Lincolnshire and Northamptonshire</ms:long_name>
+              <ms:short_name>Lincs and Northants</ms:short_name>
+              <ms:code>LCNNTH</ms:code>
+              <ms:area_id>3</ms:area_id>
+              <ms:area_name>Northern</ms:area_name>
+              <ms:st_area_shape_>9270202427.530003</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>1148848.464792307</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Water_Management_Areas>
+          </gml:featureMember>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Water_Management_Areas fid="Administrative_Boundaries_Water_Management_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Staffordshire Warwickshire and West Midlands</ms:long_name>
+              <ms:short_name>Staffs Warks and West Mids</ms:short_name>
+              <ms:code>STWKWM</ms:code>
+              <ms:area_id>29</ms:area_id>
+              <ms:area_name>Central</ms:area_name>
+              <ms:st_area_shape_>6460280400.1</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>759189.708848595</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Water_Management_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Wed, 28 Aug 2019 16:25:23 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
[CVE-2019-5477](https://github.com/sparklemotion/nokogiri/issues/1915) identifies an issue in Nokogiri version 1.10.3. The resolution is to upgrade to version 1.10.4.

Hakiri is failing our build because our minimum requirement is 1.10.3 hence this change to bump it to the fixed version.