### PR TITLE
Fix security issue with Nokogiri

### DIFF
--- a/defra_ruby_area.gemspec
+++ b/defra_ruby_area.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   # The response from the area WFS services is in XML so we need Nokogiri to
   # parse it
-  spec.add_dependency "nokogiri", "~> 1.10.4"
+  spec.add_dependency "nokogiri", "~> 1.10.7"
 
   # Use rest-client for external requests, eg. to Companies House
   spec.add_dependency "rest-client", "~> 2.0"


### PR DESCRIPTION
Hakiri has flagged the project due to CVE-2019-13117 with Nokogiri.

The issue has been fixed in version 1.10.5 onwards, whilst the latest version is Nokogiri 1.10.7. So we're resolving the Hakiri flag by setting the version of Nokogiri to the latest.