### PR TITLE
Upgrade nokogiri in response to security alerts

### DIFF
--- a/defra_ruby_area.gemspec
+++ b/defra_ruby_area.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   # The response from the area WFS services is in XML so we need Nokogiri to
   # parse it
-  spec.add_dependency "nokogiri", ">= 1.11.1", "< 1.13.0"
+  spec.add_dependency "nokogiri", ">= 1.13.2"
 
   # Use rest-client for external requests, eg. to Companies House
   spec.add_dependency "rest-client", "~> 2.0"


### PR DESCRIPTION
libxslt: [CVE-2021-30560](https://nvd.nist.gov/vuln/detail/CVE-2021-30560) (CVSS 8.8, High severity)
libxml2: [CVE-2022-23308](https://nvd.nist.gov/vuln/detail/CVE-2022-23308) (Unspecified severity, see more information below)